### PR TITLE
Adding Pricing model as Java persistent entities

### DIFF
--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -83,6 +83,11 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/discovery/src/main/java/io/github/cloudiator/iaas/discovery/DiscoveryAgent.java
+++ b/discovery/src/main/java/io/github/cloudiator/iaas/discovery/DiscoveryAgent.java
@@ -22,14 +22,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import de.uniulm.omi.cloudiator.util.configuration.Configuration;
 import io.github.cloudiator.iaas.discovery.config.DiscoveryModule;
-import io.github.cloudiator.iaas.discovery.messaging.CloudAddedSubscriber;
-import io.github.cloudiator.iaas.discovery.messaging.CloudQuerySubscriber;
-import io.github.cloudiator.iaas.discovery.messaging.DeleteCloudSubscriber;
-import io.github.cloudiator.iaas.discovery.messaging.DiscoveryStatusSubscriber;
-import io.github.cloudiator.iaas.discovery.messaging.HardwareQuerySubscriber;
-import io.github.cloudiator.iaas.discovery.messaging.ImageQuerySubscriber;
-import io.github.cloudiator.iaas.discovery.messaging.LocationQuerySubscriber;
-import io.github.cloudiator.iaas.discovery.messaging.QuotaQuerySubscriber;
+import io.github.cloudiator.iaas.discovery.messaging.*;
 import io.github.cloudiator.persistance.JpaModule;
 import io.github.cloudiator.util.JpaContext;
 import org.cloudiator.messaging.kafka.KafkaContext;
@@ -78,6 +71,10 @@ public class DiscoveryAgent {
     cloudQuerySubscriber.run();
 
     injector.getInstance(QuotaQuerySubscriber.class).run();
+
+    PricingQuerySubscriber pricingQuerySubscriber = injector
+            .getInstance(PricingQuerySubscriber.class);
+    pricingQuerySubscriber.run();
   }
 
 }

--- a/discovery/src/main/java/io/github/cloudiator/iaas/discovery/HardwareDiscoveryWorker.java
+++ b/discovery/src/main/java/io/github/cloudiator/iaas/discovery/HardwareDiscoveryWorker.java
@@ -31,17 +31,19 @@ import java.util.function.Predicate;
 public class HardwareDiscoveryWorker extends AbstractDiscoveryWorker<HardwareFlavor> {
 
   private final HardwareDomainRepository hardwareDomainRepository;
+  private final DiscoveryService discoveryService;
 
   @Inject
   public HardwareDiscoveryWorker(DiscoveryQueue discoveryQueue,
       DiscoveryService discoveryService, DiscoveryErrorHandler discoveryErrorHandler,
       HardwareDomainRepository hardwareDomainRepository) {
-    super(discoveryQueue, discoveryService, discoveryErrorHandler);
+    super(discoveryQueue, discoveryErrorHandler);
+    this.discoveryService = discoveryService;
     this.hardwareDomainRepository = hardwareDomainRepository;
   }
 
   @Override
-  protected Iterable<HardwareFlavor> resources(DiscoveryService discoveryService) {
+  protected Iterable<HardwareFlavor> resources() {
     return discoveryService.listHardwareFlavors();
   }
 

--- a/discovery/src/main/java/io/github/cloudiator/iaas/discovery/ImageDiscoveryWorker.java
+++ b/discovery/src/main/java/io/github/cloudiator/iaas/discovery/ImageDiscoveryWorker.java
@@ -31,17 +31,19 @@ import java.util.function.Predicate;
 public class ImageDiscoveryWorker extends AbstractDiscoveryWorker<Image> {
 
   private final ImageDomainRepository imageDomainRepository;
+  private final DiscoveryService discoveryService;
 
   @Inject
   public ImageDiscoveryWorker(DiscoveryQueue discoveryQueue,
       DiscoveryService discoveryService, DiscoveryErrorHandler discoveryErrorHandler,
       ImageDomainRepository imageDomainRepository) {
-    super(discoveryQueue, discoveryService, discoveryErrorHandler);
+    super(discoveryQueue, discoveryErrorHandler);
+    this.discoveryService = discoveryService;
     this.imageDomainRepository = imageDomainRepository;
   }
 
   @Override
-  protected Iterable<Image> resources(DiscoveryService discoveryService) {
+  protected Iterable<Image> resources() {
     return discoveryService.listImages();
   }
 

--- a/discovery/src/main/java/io/github/cloudiator/iaas/discovery/LocationDiscoveryWorker.java
+++ b/discovery/src/main/java/io/github/cloudiator/iaas/discovery/LocationDiscoveryWorker.java
@@ -31,17 +31,19 @@ import java.util.function.Predicate;
 public class LocationDiscoveryWorker extends AbstractDiscoveryWorker<Location> {
 
   private final LocationDomainRepository locationDomainRepository;
+  private final DiscoveryService discoveryService;
 
   @Inject
   public LocationDiscoveryWorker(DiscoveryQueue discoveryQueue,
       DiscoveryService discoveryService, DiscoveryErrorHandler discoveryErrorHandler,
       LocationDomainRepository locationDomainRepository) {
-    super(discoveryQueue, discoveryService, discoveryErrorHandler);
+    super(discoveryQueue, discoveryErrorHandler);
+    this.discoveryService = discoveryService;
     this.locationDomainRepository = locationDomainRepository;
   }
 
   @Override
-  protected Iterable<Location> resources(DiscoveryService discoveryService) {
+  protected Iterable<Location> resources() {
     return discoveryService.listLocations();
   }
 

--- a/discovery/src/main/java/io/github/cloudiator/iaas/discovery/PricingDiscoveryListener.java
+++ b/discovery/src/main/java/io/github/cloudiator/iaas/discovery/PricingDiscoveryListener.java
@@ -30,19 +30,10 @@ public class PricingDiscoveryListener implements DiscoveryListener {
 
         final Pricing pricing = (Pricing) o;
 
-//        speed up for now
-//        final DiscoveredPricing byId = pricingDomainRepository.findById(pricing.id());
-//
-//        if (byId != null) {
-//            LOGGER.trace(String.format("Skipping pricing %s. Already exists.", pricing));
-//            return;
-//        }
-
         DiscoveredPricing discoveredPricing = new DiscoveredPricing(pricing, "Internal-Pricing");
 
         try {
             pricingDomainRepository.save(discoveredPricing);
-            //pricingStateMachine.apply(discoveredPricing, DiscoveryItemState.OK, new Object[0]);
         } catch (Exception e) {
             LOGGER.info("Exception caught while saving discovered pricing", e);
         }

--- a/discovery/src/main/java/io/github/cloudiator/iaas/discovery/PricingDiscoveryListener.java
+++ b/discovery/src/main/java/io/github/cloudiator/iaas/discovery/PricingDiscoveryListener.java
@@ -1,0 +1,50 @@
+package io.github.cloudiator.iaas.discovery;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import de.uniulm.omi.cloudiator.sword.domain.Pricing;
+import io.github.cloudiator.domain.DiscoveredPricing;
+import io.github.cloudiator.persistance.PricingDomainRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PricingDiscoveryListener implements DiscoveryListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PricingDiscoveryListener.class);
+    private final PricingDomainRepository pricingDomainRepository;
+
+    @Inject
+    public PricingDiscoveryListener(
+            PricingDomainRepository pricingDomainRepository) {
+        this.pricingDomainRepository = pricingDomainRepository;
+    }
+
+    @Override
+    public Class<?> interestedIn() {
+        return Pricing.class;
+    }
+
+    @Override
+    @Transactional
+    public void handle(Object o) {
+
+        final Pricing pricing = (Pricing) o;
+
+//        speed up for now
+//        final DiscoveredPricing byId = pricingDomainRepository.findById(pricing.id());
+//
+//        if (byId != null) {
+//            LOGGER.trace(String.format("Skipping pricing %s. Already exists.", pricing));
+//            return;
+//        }
+
+        DiscoveredPricing discoveredPricing = new DiscoveredPricing(pricing, "Internal-Pricing");
+
+        try {
+            pricingDomainRepository.save(discoveredPricing);
+            //pricingStateMachine.apply(discoveredPricing, DiscoveryItemState.OK, new Object[0]);
+        } catch (Exception e) {
+            LOGGER.info("Exception caught while saving discovered pricing", e);
+        }
+    }
+}

--- a/discovery/src/main/java/io/github/cloudiator/iaas/discovery/PricingDiscoveryWorker.java
+++ b/discovery/src/main/java/io/github/cloudiator/iaas/discovery/PricingDiscoveryWorker.java
@@ -1,0 +1,50 @@
+package io.github.cloudiator.iaas.discovery;
+
+import com.google.inject.Inject;
+import de.uniulm.omi.cloudiator.sword.domain.Pricing;
+import de.uniulm.omi.cloudiator.sword.service.PricingService;
+import io.github.cloudiator.iaas.discovery.error.DiscoveryErrorHandler;
+import io.github.cloudiator.persistance.PricingDomainRepository;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+public class PricingDiscoveryWorker extends AbstractDiscoveryWorker<Pricing> {
+
+    private final PricingDomainRepository pricingDomainRepository;
+    private final PricingService pricingService;
+
+    @Inject
+    public PricingDiscoveryWorker(DiscoveryQueue discoveryQueue,
+                                  PricingService pricingService, DiscoveryErrorHandler discoveryErrorHandler,
+                                  PricingDomainRepository pricingDomainRepository) {
+        super(discoveryQueue, discoveryErrorHandler);
+        this.pricingService = pricingService;
+        this.pricingDomainRepository = pricingDomainRepository;
+    }
+
+    @Override
+    protected Iterable<Pricing> resources() {
+        return pricingService.listPricing();
+    }
+
+    @Override
+    protected Predicate<Pricing> filter() {
+        return new Predicate<Pricing>() {
+            @Override
+            public boolean test(Pricing pricing) {
+                return pricingDomainRepository.findById(pricing.id()) == null;
+            }
+        };
+    }
+
+    @Override
+    public long period() {
+        return 2;
+    }
+
+    @Override
+    public TimeUnit timeUnit() {
+        return TimeUnit.MINUTES;
+    }
+}

--- a/discovery/src/main/java/io/github/cloudiator/iaas/discovery/messaging/PricingQuerySubscriber.java
+++ b/discovery/src/main/java/io/github/cloudiator/iaas/discovery/messaging/PricingQuerySubscriber.java
@@ -28,9 +28,8 @@ public class PricingQuerySubscriber implements Runnable {
 
     @Override
     public void run() {
-        Subscription subscription = messageInterface.subscribe(PricingQueryRequest.class, PricingQueryRequest.parser(),
-                (requestId, pricingQueryRequest)  -> {
-
+        messageInterface.subscribe(PricingQueryRequest.class, PricingQueryRequest.parser(),
+                (requestId, pricingQueryRequest) -> {
                     try {
                         decideAndReply(requestId, pricingQueryRequest);
                     } catch (Exception e) {
@@ -64,11 +63,6 @@ public class PricingQuerySubscriber implements Runnable {
                                     PRICING_CONVERTER::apply).collect(Collectors.toList())).build();
             messageInterface.reply(requestId, pricingQueryResponse);
         } catch (Exception e) {
-            /*messageInterface.reply(PricingQueryResponse.class, requestId,
-                    General.Error.newBuilder().setCode(500).setMessage(String
-                            .format("Error while retrieving the price: %s", e.getMessage()))
-                            .build());
-            return;*/
             LOGGER.error(e.getMessage());
         }
     }

--- a/discovery/src/main/java/io/github/cloudiator/iaas/discovery/messaging/PricingQuerySubscriber.java
+++ b/discovery/src/main/java/io/github/cloudiator/iaas/discovery/messaging/PricingQuerySubscriber.java
@@ -1,0 +1,75 @@
+package io.github.cloudiator.iaas.discovery.messaging;
+
+import io.github.cloudiator.messaging.PricingMessageToPricingConverter;
+import io.github.cloudiator.persistance.PricingDomainRepository;
+import org.cloudiator.messages.General;
+import org.cloudiator.messaging.MessageInterface;
+import org.cloudiator.messaging.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.cloudiator.messages.Pricing.PricingQueryRequest;
+import org.cloudiator.messages.Pricing.PricingQueryResponse;
+
+import com.google.inject.Inject;
+
+import java.util.stream.Collectors;
+
+public class PricingQuerySubscriber implements Runnable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PricingQuerySubscriber.class);
+    private static final PricingMessageToPricingConverter PRICING_CONVERTER = PricingMessageToPricingConverter.INSTANCE;
+    private final MessageInterface messageInterface;
+    private final PricingDomainRepository pricingDomainRepository;
+
+    @Inject
+    public PricingQuerySubscriber(MessageInterface messageInterface, PricingDomainRepository pricingDomainRepository) {
+        this.messageInterface = messageInterface;
+        this.pricingDomainRepository = pricingDomainRepository;
+    }
+
+    @Override
+    public void run() {
+        Subscription subscription = messageInterface.subscribe(PricingQueryRequest.class, PricingQueryRequest.parser(),
+                (requestId, pricingQueryRequest)  -> {
+
+                    try {
+                        decideAndReply(requestId, pricingQueryRequest);
+                    } catch (Exception e) {
+                        LOGGER.error(String
+                                .format("Caught exception %s during execution of %s", e.getMessage(), this), e);
+                    }
+                });
+    }
+
+    private void decideAndReply(String requestId, PricingQueryRequest request) {
+        if (request.getCloudAPIProviderName().isEmpty()
+            || request.getUserId().isEmpty()) {
+            replyErrorNotAllParamsSupplied(requestId);
+            return;
+        }
+
+        replyForAllParams(requestId, request);
+    }
+
+    private void replyErrorNotAllParamsSupplied(String requestId) {
+        messageInterface.reply(PricingQueryResponse.class, requestId,
+                General.Error.newBuilder().setCode(500).setMessage("All request parameters have to be supplied.")
+                        .build());
+    }
+
+    private void replyForAllParams(String requestId, PricingQueryRequest request) {
+        try {
+            PricingQueryResponse pricingQueryResponse = PricingQueryResponse.newBuilder()
+                    .addAllPrices(
+                            pricingDomainRepository.getPrices(request.getCloudAPIProviderName()).stream().map(
+                                    PRICING_CONVERTER::apply).collect(Collectors.toList())).build();
+            messageInterface.reply(requestId, pricingQueryResponse);
+        } catch (Exception e) {
+            /*messageInterface.reply(PricingQueryResponse.class, requestId,
+                    General.Error.newBuilder().setCode(500).setMessage(String
+                            .format("Error while retrieving the price: %s", e.getMessage()))
+                            .build());
+            return;*/
+            LOGGER.error(e.getMessage());
+        }
+    }
+}

--- a/discovery/src/main/resources/META-INF/persistence.xml
+++ b/discovery/src/main/resources/META-INF/persistence.xml
@@ -37,6 +37,9 @@
     <class>io.github.cloudiator.persistance.HardwareOfferModel</class>
     <class>io.github.cloudiator.persistance.OperatingSystemModel</class>
     <class>io.github.cloudiator.persistance.ResourceModel</class>
+    <class>io.github.cloudiator.persistance.PricingModel</class>
+    <class>io.github.cloudiator.persistance.PricingTermsModel</class>
+    <class>io.github.cloudiator.persistance.PricingPriceDimensionsModel</class>
 
     <exclude-unlisted-classes>true</exclude-unlisted-classes>
 

--- a/discovery/src/main/resources/logback.xml
+++ b/discovery/src/main/resources/logback.xml
@@ -62,6 +62,7 @@
   <logger level="DEBUG" name="io.github.cloudiator.iaas.discovery"/>
   <logger level="DEBUG" name="org.cloudiator.messaging"/>
   <logger level="DEBUG" name="de.uniulm.omi.cloudiator.util.stateMachine"/>
+  <logger level="INFO" name="de.uniulm.omi.cloudiator.sword.multicloud.pricing.aws"/>
 
 
   <root level="WARN">

--- a/iaas-common/src/main/java/io/github/cloudiator/domain/DiscoveredPricing.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/domain/DiscoveredPricing.java
@@ -1,0 +1,133 @@
+package io.github.cloudiator.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import de.uniulm.omi.cloudiator.domain.OperatingSystem;
+import de.uniulm.omi.cloudiator.sword.domain.Api;
+import de.uniulm.omi.cloudiator.sword.domain.Location;
+import de.uniulm.omi.cloudiator.sword.domain.Pricing;
+import de.uniulm.omi.cloudiator.sword.domain.PricingTerms;
+
+import java.util.List;
+import java.util.Optional;
+
+public class DiscoveredPricing implements Pricing {
+    private final Pricing delegate;
+    private final String userId;
+
+    public DiscoveredPricing(Pricing delegate, String userId) {
+        this.delegate = delegate;
+        this.userId = userId;
+    }
+
+    @Override
+    public String getCurrency() {
+        return delegate.getCurrency();
+    }
+
+    @Override
+    public String getTenancy() {
+        return delegate.getTenancy();
+    }
+
+    @Override
+    public OperatingSystem getOperatingSystem() {
+        return delegate.getOperatingSystem();
+    }
+
+    @Override
+    public List<PricingTerms> getPricingOnDemandTerms() {
+        return delegate.getPricingOnDemandTerms();
+    }
+
+    @Override
+    public List<PricingTerms> getPricingReservedTerms() {
+        return delegate.getPricingReservedTerms();
+    }
+
+    @Override
+    public String getCloudServiceProviderName() {
+        return delegate.getCloudServiceProviderName();
+    }
+
+    @Override
+    public String getInstanceName() {
+        return delegate.getInstanceName();
+    }
+
+    @Override
+    public String getLicenseModel() {
+        return delegate.getLicenseModel();
+    }
+
+    @Override
+    public String providerId() {
+        return delegate.providerId();
+    }
+
+    @Override
+    public String id() {
+        return delegate.id();
+    }
+
+    @Override
+    @JsonProperty
+    public String name() {
+        return delegate.name();
+    }
+
+    @Override
+    public Optional<String> locationId() {
+        return delegate.locationId();
+    }
+
+    @Override
+    public Optional<Location> location() {
+        if (delegate.location().isPresent()) {
+            return Optional
+                    .of(new DiscoveredLocation(delegate.location().get(), DiscoveryItemState.UNKNOWN,
+                            userId));
+        }
+
+        return Optional.empty();
+    }
+
+    public String userId() {
+        return this.userId;
+    }
+
+    @Override
+    public String getLocationProviderId() {
+        return delegate.getLocationProviderId();
+    }
+
+    @Override
+    public Api getApi() {
+        return delegate.getApi();
+    }
+
+    @Override
+    public String getProductFamily() {
+        return delegate.getProductFamily();
+    }
+
+    @Override
+    public String getPreInstalledSw() {
+        return delegate.getPreInstalledSw();
+    }
+
+    @Override
+    public String getCapacityStatus() {
+        return delegate.getCapacityStatus();
+    }
+
+    @Override
+    public String getOperation() {
+        return delegate.getOperation();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("id", this.id()).add("delegate", this.delegate).toString();
+    }
+}

--- a/iaas-common/src/main/java/io/github/cloudiator/messaging/PricingMessageToPricingConverter.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/messaging/PricingMessageToPricingConverter.java
@@ -1,11 +1,13 @@
 package io.github.cloudiator.messaging;
 
+import de.uniulm.omi.cloudiator.sword.domain.PricingDimensions;
 import de.uniulm.omi.cloudiator.util.OneWayConverter;
 import io.github.cloudiator.domain.DiscoveredPricing;
 import org.cloudiator.messages.entities.IaasEntities;
 import org.cloudiator.messages.entities.IaasEntities.Price.Builder;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 
 public class PricingMessageToPricingConverter implements OneWayConverter<DiscoveredPricing, IaasEntities.Price> {
     public static final PricingMessageToPricingConverter INSTANCE = new PricingMessageToPricingConverter();
@@ -16,16 +18,29 @@ public class PricingMessageToPricingConverter implements OneWayConverter<Discove
     @Nullable
     @Override
     public IaasEntities.Price apply(@Nullable DiscoveredPricing discoveredPricing) {
-        Builder builder = IaasEntities.Price.newBuilder()
-                .setCloudAPIProviderName(discoveredPricing.getApi().providerName())
-                .setCurrency(discoveredPricing.getCurrency())
-                .setHardwareProviderId(discoveredPricing.getInstanceName())
-                .setId(discoveredPricing.id())
-                .setLocationProviderId(discoveredPricing.getLocationProviderId())
-                .setOsArchitecture(discoveredPricing.getOperatingSystem().operatingSystemArchitecture().name())
-                .setOsFamily(discoveredPricing.getOperatingSystem().operatingSystemFamily().name())
-                .setPrice(discoveredPricing.getPricingOnDemandTerms().get(0).getPricingDimensions().get(0).getPricePerUnit().doubleValue());
-
-        return builder.build();
+        if(discoveredPricing != null) {
+            return IaasEntities.Price.newBuilder()
+                    .setCloudAPIProviderName(discoveredPricing.getApi().providerName())
+                    .setCurrency(discoveredPricing.getCurrency())
+                    .setHardwareProviderId(discoveredPricing.getInstanceName())
+                    .setId(discoveredPricing.id())
+                    .setLocationProviderId(discoveredPricing.getLocationProviderId())
+                    .setOsArchitecture(discoveredPricing.getOperatingSystem().operatingSystemArchitecture().name())
+                    .setOsFamily(discoveredPricing.getOperatingSystem().operatingSystemFamily().name())
+                    .setPrice(discoveredPricing.getPricingOnDemandTerms()
+                            .stream()
+                            .findFirst()
+                            .flatMap(pricingTerms ->
+                                    pricingTerms.getPricingDimensions()
+                                            .stream()
+                                            .findFirst()
+                                            .map(PricingDimensions::getPricePerUnit)
+                            )
+                            .map(BigDecimal::doubleValue)
+                            .orElse(-1d)
+                    )
+                    .build();
+        }
+        return null;
     }
 }

--- a/iaas-common/src/main/java/io/github/cloudiator/messaging/PricingMessageToPricingConverter.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/messaging/PricingMessageToPricingConverter.java
@@ -1,0 +1,31 @@
+package io.github.cloudiator.messaging;
+
+import de.uniulm.omi.cloudiator.util.OneWayConverter;
+import io.github.cloudiator.domain.DiscoveredPricing;
+import org.cloudiator.messages.entities.IaasEntities;
+import org.cloudiator.messages.entities.IaasEntities.Price.Builder;
+
+import javax.annotation.Nullable;
+
+public class PricingMessageToPricingConverter implements OneWayConverter<DiscoveredPricing, IaasEntities.Price> {
+    public static final PricingMessageToPricingConverter INSTANCE = new PricingMessageToPricingConverter();
+
+    private PricingMessageToPricingConverter() {
+    }
+
+    @Nullable
+    @Override
+    public IaasEntities.Price apply(@Nullable DiscoveredPricing discoveredPricing) {
+        Builder builder = IaasEntities.Price.newBuilder()
+                .setCloudAPIProviderName(discoveredPricing.getApi().providerName())
+                .setCurrency(discoveredPricing.getCurrency())
+                .setHardwareProviderId(discoveredPricing.getInstanceName())
+                .setId(discoveredPricing.id())
+                .setLocationProviderId(discoveredPricing.getLocationProviderId())
+                .setOsArchitecture(discoveredPricing.getOperatingSystem().operatingSystemArchitecture().name())
+                .setOsFamily(discoveredPricing.getOperatingSystem().operatingSystemFamily().name())
+                .setPrice(discoveredPricing.getPricingOnDemandTerms().get(0).getPricingDimensions().get(0).getPricePerUnit().doubleValue());
+
+        return builder.build();
+    }
+}

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/ApiDomainRepository.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/ApiDomainRepository.java
@@ -23,6 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.inject.Inject;
 import de.uniulm.omi.cloudiator.sword.domain.Api;
 
+import java.util.List;
+
 class ApiDomainRepository {
 
   private static final ApiConverter API_CONVERTER = new ApiConverter();
@@ -36,6 +38,11 @@ class ApiDomainRepository {
   public Api findByProviderName(String providerName) {
     checkNotNull(providerName, "providerName is null");
     return API_CONVERTER.apply(apiModelRepository.findByProviderName(providerName));
+  }
+
+  public ApiModel findModelByProviderName(String providerName) {
+    checkNotNull(providerName, "providerName is null");
+    return apiModelRepository.findByProviderName(providerName);
   }
 
   public void save(Api domain) {
@@ -55,5 +62,9 @@ class ApiDomainRepository {
 
   private ApiModel createModel(Api domain) {
     return new ApiModel(domain.providerName());
+  }
+
+  public List<ApiModel> findAll() {
+    return apiModelRepository.findAll();
   }
 }

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/JpaModule.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/JpaModule.java
@@ -73,6 +73,11 @@ public class JpaModule extends AbstractModule {
     }).to(new TypeLiteral<BaseResourceRepositoryJpa<ImageModel>>() {
     });
 
+    bind(new TypeLiteral<ModelRepository<PricingModel>>() {
+    }).to(new TypeLiteral<BaseModelRepositoryJpa<PricingModel>>() {
+    });
+    bind(PricingModelRepository.class).to(PricingModelRepositoryJpa.class);
+
     bind(LocationModelRepository.class).to(LocationModelRepositoryJpa.class);
 
     bind(new TypeLiteral<ModelRepository<OperatingSystemModel>>() {

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/OperatingSystemDomainRepository.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/OperatingSystemDomainRepository.java
@@ -20,6 +20,11 @@ package io.github.cloudiator.persistance;
 
 import com.google.inject.Inject;
 import de.uniulm.omi.cloudiator.domain.OperatingSystem;
+import de.uniulm.omi.cloudiator.domain.OperatingSystemArchitecture;
+import de.uniulm.omi.cloudiator.domain.OperatingSystemFamily;
+import de.uniulm.omi.cloudiator.domain.OperatingSystemVersion;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Created by daniel on 02.06.17.
@@ -42,6 +47,19 @@ public class OperatingSystemDomainRepository {
     final OperatingSystemModel model = createModel(domain);
     operatingSystemModelRepository.save(model);
     return model;
+  }
+
+  OperatingSystemModel saveOrGet(OperatingSystem domain) {
+    checkNotNull(domain, "domain is null");
+    OperatingSystemModel operatingSystemModel = operatingSystemModelRepository.findByArchitectureFamilyVersion(domain.operatingSystemArchitecture(), domain.operatingSystemFamily(), domain.operatingSystemVersion());
+    if (operatingSystemModel == null) {
+      operatingSystemModel = saveAndGet(domain);
+    }
+    return operatingSystemModel;
+  }
+
+  public OperatingSystemModel findByArchitectureFamilyVersion(OperatingSystemArchitecture architecture, OperatingSystemFamily family, OperatingSystemVersion version) {
+    return operatingSystemModelRepository.findByArchitectureFamilyVersion(architecture, family, version);
   }
 
   void update(OperatingSystem domain, OperatingSystemModel model) {

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/OperatingSystemModelRepository.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/OperatingSystemModelRepository.java
@@ -18,6 +18,13 @@
 
 package io.github.cloudiator.persistance;
 
-interface OperatingSystemModelRepository extends ModelRepository<OperatingSystemModel> {
+import de.uniulm.omi.cloudiator.domain.OperatingSystemArchitecture;
+import de.uniulm.omi.cloudiator.domain.OperatingSystemFamily;
+import de.uniulm.omi.cloudiator.domain.OperatingSystemVersion;
 
+import javax.annotation.Nullable;
+
+interface OperatingSystemModelRepository extends ModelRepository<OperatingSystemModel> {
+    @Nullable
+    OperatingSystemModel findByArchitectureFamilyVersion(OperatingSystemArchitecture architecture, OperatingSystemFamily family, OperatingSystemVersion version);
 }

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/OperatingSystemModelRepositoryJpa.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/OperatingSystemModelRepositoryJpa.java
@@ -33,30 +33,32 @@ import javax.persistence.Query;
 class OperatingSystemModelRepositoryJpa extends
     BaseModelRepositoryJpa<OperatingSystemModel> implements OperatingSystemModelRepository {
 
+  private String queryStringWithVersion2findByArchFamVer;
+  private String queryStringWithoutVersion2findByArchFamVer;
+
   @Inject
   protected OperatingSystemModelRepositoryJpa(
       Provider<EntityManager> entityManager,
       TypeLiteral<OperatingSystemModel> type) {
     super(entityManager, type);
+    queryStringWithVersion2findByArchFamVer = String
+            .format(
+                    "from %s where operatingSystemArchitecture=:operatingSystemArchitecture and operatingSystemFamily=:operatingSystemFamily and version=:version",
+                    super.type.getName());
+    queryStringWithoutVersion2findByArchFamVer = String
+            .format(
+                    "from %s where operatingSystemArchitecture=:operatingSystemArchitecture and operatingSystemFamily=:operatingSystemFamily and version is null",
+                    super.type.getName());
   }
 
   @Nullable
   @Override
   public OperatingSystemModel findByArchitectureFamilyVersion(OperatingSystemArchitecture architecture, OperatingSystemFamily family, OperatingSystemVersion version) {
-    String queryStringWithVersion = String
-            .format(
-                    "from %s where operatingSystemArchitecture=:operatingSystemArchitecture and operatingSystemFamily=:operatingSystemFamily and version=:version",
-                    type.getName());
-    String queryStringWithoutVersion = String
-            .format(
-                    "from %s where operatingSystemArchitecture=:operatingSystemArchitecture and operatingSystemFamily=:operatingSystemFamily and version is null",
-                    type.getName());
-
     Query query;
     if (version.version() == null) {
-      query = em().createQuery(queryStringWithoutVersion);
+      query = em().createQuery(queryStringWithoutVersion2findByArchFamVer);
     } else {
-      query = em().createQuery(queryStringWithVersion);
+      query = em().createQuery(queryStringWithVersion2findByArchFamVer);
       query.setParameter("version", version.version());
     }
 

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingConverter.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingConverter.java
@@ -1,0 +1,72 @@
+package io.github.cloudiator.persistance;
+
+import de.uniulm.omi.cloudiator.domain.OperatingSystemBuilder;
+import de.uniulm.omi.cloudiator.sword.domain.ApiBuilder;
+import de.uniulm.omi.cloudiator.sword.domain.PricingBuilder;
+import de.uniulm.omi.cloudiator.sword.domain.PricingDimensions;
+import de.uniulm.omi.cloudiator.sword.domain.PricingTerms;
+import de.uniulm.omi.cloudiator.util.OneWayConverter;
+import io.github.cloudiator.domain.DiscoveredPricing;
+import io.github.cloudiator.messaging.OperatingSystemConverter;
+
+import javax.annotation.Nullable;
+import java.util.stream.Collectors;
+
+public class PricingConverter implements OneWayConverter<PricingModel, DiscoveredPricing> {
+    @Nullable
+    @Override
+    public DiscoveredPricing apply(@Nullable PricingModel pricingModel) {
+        if(pricingModel == null) {
+            return null;
+        }
+
+        return new DiscoveredPricing(PricingBuilder.newBuilder()
+        .name(pricingModel.getName())
+        .providerId(pricingModel.getProviderId())
+        .id(pricingModel.getCloudUniqueId())
+        .location(null)
+        .locationProviderId(pricingModel.getLocationProviderId())
+        .cloudServiceProviderName(pricingModel.getCloudServiceProviderName())
+        .currency(pricingModel.getCurrency())
+        .operatingSystem(OperatingSystemBuilder.newBuilder()
+                .architecture(pricingModel.getOperatingSystemModel().operatingSystemArchitecture())
+                .family(pricingModel.getOperatingSystemModel().operatingSystemFamily())
+                .version(pricingModel.getOperatingSystemModel().operatingSystemVersion())
+                .build())
+        .api(ApiBuilder.newBuilder().providerName(pricingModel.getApiModel().getProviderName()).build())
+        .tenancy(pricingModel.getTenancy())
+        .instanceName(pricingModel.getInstanceName())
+        .licenseModel(pricingModel.getLicenseModel())
+        .operation(pricingModel.getOperation())
+        .productFamily(pricingModel.getProductFamily())
+        .capacityStatus(pricingModel.getCapacityStatus())
+        .preInstalledSw(pricingModel.getPreInstalledSw())
+        .onDemandTerms(
+                pricingModel.getPricingTermsModels().stream()
+                .filter(term -> term.getTermsType().equals("OnDemand"))
+                .map(term -> new PricingTerms(
+                        term.getPricingPriceDimensionsModels().stream()
+                        .map(priceDimension -> new PricingDimensions(priceDimension.getPricePerUnit(), priceDimension.getUnit(), priceDimension.getDescription(), priceDimension.getBeginRange(), priceDimension.getEndRange()))
+                        .collect(Collectors.toList()),
+                        term.getLeaseContractLength(),
+                        term.getOfferingClass(),
+                        term.getPurchaseOption())
+
+                )
+                .collect(Collectors.toList()))
+        .reservedTerms(
+                pricingModel.getPricingTermsModels().stream()
+                        .filter(term -> term.getTermsType().equals("Reserved"))
+                        .map(term -> new PricingTerms(
+                                term.getPricingPriceDimensionsModels().stream()
+                                        .map(priceDimension -> new PricingDimensions(priceDimension.getPricePerUnit(), priceDimension.getUnit(), priceDimension.getDescription(), priceDimension.getBeginRange(), priceDimension.getEndRange()))
+                                        .collect(Collectors.toList()),
+                                term.getLeaseContractLength(),
+                                term.getOfferingClass(),
+                                term.getPurchaseOption())
+
+                        )
+                        .collect(Collectors.toList()))
+        .build(), "Internal-Pricing");
+    }
+}

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingDomainRepository.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingDomainRepository.java
@@ -1,0 +1,191 @@
+package io.github.cloudiator.persistance;
+
+import com.google.inject.Inject;
+import de.uniulm.omi.cloudiator.domain.OperatingSystemArchitecture;
+import de.uniulm.omi.cloudiator.domain.OperatingSystemFamily;
+import de.uniulm.omi.cloudiator.domain.OperatingSystemVersion;
+import de.uniulm.omi.cloudiator.domain.OperatingSystemVersions;
+import de.uniulm.omi.cloudiator.sword.domain.Api;
+import io.github.cloudiator.domain.DiscoveredPricing;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+public class PricingDomainRepository {
+    private static final PricingConverter PRICING_CONVERTER = new PricingConverter();
+    private final PricingModelRepository pricingModelRepository;
+    private final ApiDomainRepository apiDomainRepository;
+    private final OperatingSystemDomainRepository operatingSystemDomainRepository;
+    private static final Logger LOGGER = LoggerFactory.getLogger(PricingDomainRepository.class);
+
+    @Inject
+    public PricingDomainRepository(PricingModelRepository pricingModelRepository, ApiDomainRepository apiDomainRepository, OperatingSystemDomainRepository operatingSystemDomainRepository) {
+        this.pricingModelRepository = pricingModelRepository;
+        this.apiDomainRepository = apiDomainRepository;
+        this.operatingSystemDomainRepository = operatingSystemDomainRepository;
+    }
+
+    public DiscoveredPricing findById(String id) {
+        return PRICING_CONVERTER.apply(pricingModelRepository.findByCloudUniqueId(id));
+    }
+
+    public double findPrice(String cloudProviderName, String locationProviderId, String hardwareProviderId, String osArchitecture, String osFamily) throws Exception {
+        ApiModel api = apiDomainRepository.findModelByProviderName(cloudProviderName);
+
+        OperatingSystemArchitecture operatingSystemArchitecture = OperatingSystemArchitecture.valueOf(osArchitecture);
+        OperatingSystemArchitecture operatingSystemArchitectureFind;
+        switch (operatingSystemArchitecture) {
+            case AMD64:
+            case UNKNOWN: {
+                operatingSystemArchitectureFind = OperatingSystemArchitecture.AMD64;
+                break;
+            }
+            case I368: {
+                operatingSystemArchitectureFind = OperatingSystemArchitecture.I368;
+                break;
+            }
+            default: {
+                throw new Exception(String.format("No data for Operating System Architecture %s", osArchitecture));
+            }
+        }
+
+        OperatingSystemFamily operatingSystemFamily = OperatingSystemFamily.valueOf(osFamily);
+        OperatingSystemFamily operatingSystemFamilyFind;
+        switch (operatingSystemFamily) {
+            case RHEL: {
+                operatingSystemFamilyFind = OperatingSystemFamily.RHEL;
+                break;
+            }
+            case SUSE: {
+                operatingSystemFamilyFind = OperatingSystemFamily.SUSE;
+                break;
+            }
+            case WINDOWS: {
+                operatingSystemFamilyFind = OperatingSystemFamily.WINDOWS;
+                break;
+            }
+            case CENTOS:
+            case AMZN_LINUX:
+            case DEBIAN:
+            case UNKNOWN:
+            case UBUNTU: {
+                operatingSystemFamilyFind = OperatingSystemFamily.UBUNTU;
+                break;
+            }
+            default: {
+                throw new Exception(String.format("No data for Operating System Family %s", osFamily));
+            }
+        }
+
+        OperatingSystemModel operatingSystem = operatingSystemDomainRepository.findByArchitectureFamilyVersion(
+                operatingSystemArchitectureFind,
+                operatingSystemFamilyFind,
+                OperatingSystemVersions.unknown());
+
+        PricingModel pricingModel = pricingModelRepository.findByCSPHardwareLocationOS(api.getId(), locationProviderId, hardwareProviderId, operatingSystem.getId());
+
+        if(pricingModel != null) {
+            return pricingModel.getPricingTermsModels().get(0).getPricingPriceDimensionsModels().get(0).getPricePerUnit().doubleValue();
+        } else {
+            throw new Exception(String.format("No pricing data found for: CSP: %s, Location: %s, Instance: %s, OS: %s, %s", cloudProviderName, locationProviderId, hardwareProviderId, osArchitecture, osFamily));
+        }
+    }
+
+    public List<DiscoveredPricing> getPrices(String cloudAPIProviderName) throws Exception {
+        ApiModel api = apiDomainRepository.findModelByProviderName(cloudAPIProviderName);
+
+        List<PricingModel> pricingModels = pricingModelRepository.getPrices(api.getId());
+
+        if(pricingModels != null) {
+            return pricingModels.stream().map(PRICING_CONVERTER::apply).collect(Collectors.toList());
+        } else {
+            throw new Exception(String.format("No pricing data found for Cloud API Provider Name: %s", cloudAPIProviderName));
+        }
+    }
+
+    public void save(DiscoveredPricing domain) {
+        checkNotNull(domain, "domain is null");
+        saveAndGet(domain);
+    }
+
+    PricingModel saveAndGet(DiscoveredPricing domain) {
+        checkNotNull(domain, "domain is null");
+
+        PricingModel model = pricingModelRepository.findByCloudUniqueId(domain.id());
+        if (model == null) {
+            model = createModel(domain);
+        } else {
+            //TODO updating pricing model ?
+            LOGGER.info("pricing model found in Pricing Model Repository, CloudUniqueId = {}", domain.id());
+        }
+        pricingModelRepository.save(model);
+
+        return model;
+    }
+
+    private PricingModel createModel(DiscoveredPricing domain) {
+        final ApiModel apiModel = getApiModel(domain);
+
+        checkState(apiModel != null, String
+                .format("Cannot save pricing %s as related apiModel is missing.",
+                        domain));
+
+        OperatingSystemModel operatingSystemModel = operatingSystemDomainRepository
+                .saveOrGet(domain.getOperatingSystem());
+
+        PricingModel pricingModel = new PricingModel(domain.id(), domain.providerId(), domain.name(),
+                domain.getInstanceName(), domain.getCloudServiceProviderName(), domain.getLicenseModel(),
+                domain.getLocationProviderId(), domain.getCurrency(), domain.getTenancy(), operatingSystemModel,
+                null,
+                apiModel, domain.getProductFamily(), domain.getPreInstalledSw(), domain.getCapacityStatus(), domain.getOperation());
+
+        List<PricingTermsModel> pricingOnDemandTermsModels = domain.getPricingOnDemandTerms().stream()
+                .map(term -> new PricingTermsModel(term.getLeaseContractLength(), term.getOfferingClass(),
+                        term.getPurchaseOption(),
+                        term.getPricingDimensions().stream()
+                                .map(dim -> new PricingPriceDimensionsModel(dim.getPricePerUnit(), dim.getUnit(), dim.getDescription(), dim.getBeginRange(), dim.getEndRange()))
+                                .collect(Collectors.toList()),
+                        "OnDemand", pricingModel))
+                .collect(Collectors.toList());
+
+        pricingOnDemandTermsModels.forEach(pricingTermsModel ->
+                pricingTermsModel.getPricingPriceDimensionsModels().forEach(pricingPriceDimensionsModel ->
+                        pricingPriceDimensionsModel.setPricingTermsModel(pricingTermsModel)));
+
+        List<PricingTermsModel> pricingReservedTermsModels = domain.getPricingReservedTerms().stream()
+                .map(term -> new PricingTermsModel(term.getLeaseContractLength(), term.getOfferingClass(),
+                        term.getPurchaseOption(),
+                        term.getPricingDimensions().stream()
+                                .map(dim -> new PricingPriceDimensionsModel(dim.getPricePerUnit(), dim.getUnit(), dim.getDescription(), dim.getBeginRange(), dim.getEndRange()))
+                                .collect(Collectors.toList()),
+                        "Reserved", pricingModel))
+                .collect(Collectors.toList());
+
+        pricingReservedTermsModels.forEach(pricingTermsModel ->
+                pricingTermsModel.getPricingPriceDimensionsModels().forEach(pricingPriceDimensionsModel ->
+                        pricingPriceDimensionsModel.setPricingTermsModel(pricingTermsModel)));
+
+        pricingModel.setPricingTermsModels(Stream.concat(pricingOnDemandTermsModels.stream(), pricingReservedTermsModels.stream()).collect(Collectors.toList()));
+
+        return pricingModel;
+    }
+
+    private ApiModel getApiModel(DiscoveredPricing domain) {
+        List<ApiModel> apiModels = apiDomainRepository.findAll();
+        Optional<ApiModel> apiModel = apiModels.stream().filter(model -> model.getProviderName().matches("(?i).*aws.*")).findAny();
+        if(apiModel.isPresent()) {
+            return apiModel.get();
+        }
+        else {
+            return apiDomainRepository.saveOrGet(domain.getApi());
+        }
+    }
+
+}

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingDomainRepository.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingDomainRepository.java
@@ -180,12 +180,7 @@ public class PricingDomainRepository {
     private ApiModel getApiModel(DiscoveredPricing domain) {
         List<ApiModel> apiModels = apiDomainRepository.findAll();
         Optional<ApiModel> apiModel = apiModels.stream().filter(model -> model.getProviderName().matches("(?i).*aws.*")).findAny();
-        if(apiModel.isPresent()) {
-            return apiModel.get();
-        }
-        else {
-            return apiDomainRepository.saveOrGet(domain.getApi());
-        }
+        return apiModel.orElseGet(() -> apiDomainRepository.saveOrGet(domain.getApi()));
     }
 
 }

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingModel.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingModel.java
@@ -1,9 +1,5 @@
 package io.github.cloudiator.persistance;
 
-import io.github.cloudiator.domain.DiscoveryItemState;
-import org.apache.kafka.common.protocol.types.Field;
-
-import javax.annotation.Nullable;
 import javax.persistence.*;
 import java.util.List;
 
@@ -23,17 +19,12 @@ public class PricingModel extends Model {
     private String cloudServiceProviderName;
     @Column(nullable = false)
     private String currency;
-    @Column(nullable = true)
     private String licenseModel;
-    @Column(nullable = true)
     private String tenancy;
     @Column(nullable = false)
     private String productFamily;
-    @Column(nullable = true)
     private String preInstalledSw;
-    @Column(nullable = true)
     private String capacityStatus;
-    @Column(nullable = true)
     private String operation;
     @Column(nullable = false)
     private String locationProviderId;

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingModel.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingModel.java
@@ -1,0 +1,203 @@
+package io.github.cloudiator.persistance;
+
+import io.github.cloudiator.domain.DiscoveryItemState;
+import org.apache.kafka.common.protocol.types.Field;
+
+import javax.annotation.Nullable;
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Inheritance(strategy = javax.persistence.InheritanceType.TABLE_PER_CLASS)
+public class PricingModel extends Model {
+    @Column(nullable = false, updatable = false)
+    @Lob
+    private String cloudUniqueId;
+    @Column(nullable = false, updatable = false)
+    private String providerId;
+    @Column(nullable = false, updatable = false)
+    private String name;
+    @Column(nullable = false)
+    private String instanceName;
+    @Column(nullable = false)
+    private String cloudServiceProviderName;
+    @Column(nullable = false)
+    private String currency;
+    @Column(nullable = true)
+    private String licenseModel;
+    @Column(nullable = true)
+    private String tenancy;
+    @Column(nullable = false)
+    private String productFamily;
+    @Column(nullable = true)
+    private String preInstalledSw;
+    @Column(nullable = true)
+    private String capacityStatus;
+    @Column(nullable = true)
+    private String operation;
+    @Column(nullable = false)
+    private String locationProviderId;
+    @ManyToOne(optional = false)
+    private OperatingSystemModel operatingSystemModel;
+    @ManyToOne(optional = false)
+    private ApiModel apiModel;
+
+    @OneToMany(mappedBy="pricingModel", cascade = CascadeType.ALL)
+    private List<PricingTermsModel> pricingTermsModels;
+
+    /**
+     * Empty constructor for hibernate.
+     */
+    protected PricingModel() {
+    }
+
+    public PricingModel(String cloudUniqueId, String providerId, String name, String instanceName, String cloudServiceProviderName,
+                        String licenseModel, String locationProviderId, String currency, String tenancy, OperatingSystemModel operatingSystemModel,
+                        List<PricingTermsModel> pricingTermsModels, ApiModel apiModel, String productFamily, String preInstalledSw,
+                        String capacityStatus, String operation) { // , DiscoveryItemState state
+        this.cloudUniqueId = cloudUniqueId;
+        this.providerId = providerId;
+        this.name = name;
+        this.locationProviderId = locationProviderId;
+        this.currency = currency;
+        this.tenancy = tenancy;
+        this.operatingSystemModel = operatingSystemModel;
+        this.pricingTermsModels = pricingTermsModels;
+        this.instanceName = instanceName;
+        this.cloudServiceProviderName = cloudServiceProviderName;
+        this.licenseModel = licenseModel;
+        this.apiModel = apiModel;
+        this.productFamily = productFamily;
+        this.preInstalledSw = preInstalledSw;
+        this.capacityStatus = capacityStatus;
+        this.operation = operation;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getTenancy() {
+        return tenancy;
+    }
+
+    public void setTenancy(String tenancy) {
+        this.tenancy = tenancy;
+    }
+
+    public OperatingSystemModel getOperatingSystemModel() {
+        return operatingSystemModel;
+    }
+
+    public void setOperatingSystemModel(OperatingSystemModel operatingSystemModel) {
+        this.operatingSystemModel = operatingSystemModel;
+    }
+
+    public String getInstanceName() {
+        return instanceName;
+    }
+
+    public void setInstanceName(String instanceName) {
+        this.instanceName= instanceName;
+    }
+
+    public String getLicenseModel() {
+        return licenseModel;
+    }
+
+    public void setLicenseModel(String licenseModel) {
+        this.licenseModel = licenseModel;
+    }
+
+    public List<PricingTermsModel> getPricingTermsModels() {
+        return pricingTermsModels;
+    }
+
+    public void setPricingTermsModels(List<PricingTermsModel> pricingTermsModels) {
+        this.pricingTermsModels = pricingTermsModels;
+    }
+
+    public String getCloudUniqueId() {
+        return cloudUniqueId;
+    }
+
+    public void setCloudUniqueId(String cloudUniqueId) {
+        this.cloudUniqueId= cloudUniqueId;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId= providerId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name= name;
+    }
+
+    public String getLocationProviderId() {
+        return locationProviderId;
+    }
+
+    public void setLocationProviderId(String locationProviderId) {
+        this.locationProviderId = locationProviderId;
+    }
+
+    public ApiModel getApiModel() {
+        return apiModel;
+    }
+
+    public void setApiModel(ApiModel apiModel) {
+        this.apiModel = apiModel;
+    }
+
+    public String getCloudServiceProviderName() {
+        return cloudServiceProviderName;
+    }
+
+    public void setCloudServiceProviderName(String cloudServiceProviderName) {
+        this.cloudServiceProviderName = cloudServiceProviderName;
+    }
+
+    public String getProductFamily() {
+        return productFamily;
+    }
+
+    public void setProductFamily(String productFamily) {
+        this.productFamily = productFamily;
+    }
+
+    public String getPreInstalledSw() {
+        return preInstalledSw;
+    }
+
+    public void setPreInstalledSw(String preInstalledSw) {
+        this.preInstalledSw = preInstalledSw;
+    }
+
+    public String getCapacityStatus() {
+        return capacityStatus;
+    }
+
+    public void setCapacityStatus(String capacityStatus) {
+        this.capacityStatus = capacityStatus;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
+}

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingModelRepository.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingModelRepository.java
@@ -1,0 +1,15 @@
+package io.github.cloudiator.persistance;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public interface PricingModelRepository extends ModelRepository<PricingModel> {
+    @Nullable
+    PricingModel findByCloudUniqueId(String cloudUniqueId);
+
+    @Nullable
+    PricingModel findByCSPHardwareLocationOS(Long apiId, String locationProviderId, String hardwareProviderId, Long operatingSystemId);
+
+    @Nullable
+    List<PricingModel> getPrices(Long apiId);
+}

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingModelRepositoryJpa.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingModelRepositoryJpa.java
@@ -1,0 +1,81 @@
+package io.github.cloudiator.persistance;
+
+import com.google.inject.Provider;
+import com.google.inject.TypeLiteral;
+import de.uniulm.omi.cloudiator.domain.OperatingSystem;
+import de.uniulm.omi.cloudiator.sword.domain.Api;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.Query;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class PricingModelRepositoryJpa extends BaseModelRepositoryJpa<PricingModel> implements PricingModelRepository {
+    @Inject
+    public PricingModelRepositoryJpa(Provider<EntityManager> entityManager, TypeLiteral<PricingModel> type) {
+        super(entityManager, type);
+    }
+
+    @Nullable
+    @Override
+    public PricingModel findByCloudUniqueId(String cloudUniqueId) {
+        checkNotNull(cloudUniqueId, "cloudUniqueId is null");
+        String queryString = String
+                .format("from %s where cloudUniqueId=:cloudUniqueId", type.getName());
+        Query query = em().createQuery(queryString).setParameter("cloudUniqueId", cloudUniqueId);
+        try {
+            //noinspection unchecked
+            return (PricingModel) query.getSingleResult();
+        } catch (NoResultException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    @Override
+    public PricingModel findByCSPHardwareLocationOS(Long apiId, String locationProviderId, String hardwareProviderId, Long operatingSystemId) {
+        checkNotNull(apiId, "apiId is null");
+        checkNotNull(locationProviderId, "locationProviderId is null");
+        checkNotNull(hardwareProviderId, "hardwareProviderId is null");
+        checkNotNull(operatingSystemId, "operatingSystemId is null");
+
+        String queryString = String.format(
+                "select pm from %s pm inner join pm.pricingTermsModels ptm inner join ptm.pricingPriceDimensionsModels pdm " +
+                        "where pm.instanceName = :hardwareProviderId and pm.locationProviderId = :locationProviderId and preInstalledSw = 'NA' " +
+                        "and tenancy = 'Shared' and licenseModel = 'No License required' and operatingSystemModel_id = :operatingSystemId " +
+                        "and termsType = 'OnDemand' and apiModel_id = :apiId",
+                type.getName());
+
+        Query query = em().createQuery(queryString)
+                .setParameter("hardwareProviderId", hardwareProviderId)
+                .setParameter("locationProviderId", locationProviderId)
+                .setParameter("operatingSystemId", operatingSystemId)
+                .setParameter("apiId", apiId);
+
+        @SuppressWarnings("unchecked") List<PricingModel> pricingModels = query.getResultList();
+        return pricingModels.stream().findFirst().orElse(null);
+    }
+
+    @Nullable
+    @Override
+    public List<PricingModel> getPrices(Long apiId) {
+        checkNotNull(apiId, "apiId is null");
+
+        String queryString = String.format(
+                "select pm from %s pm inner join pm.pricingTermsModels ptm inner join ptm.pricingPriceDimensionsModels pdm " +
+                        "where preInstalledSw = 'NA' and tenancy = 'Shared' and licenseModel = 'No License required' and termsType = 'OnDemand' and apiModel_id = :apiId",
+                type.getName());
+
+        Query query = em().createQuery(queryString)
+                .setParameter("apiId", apiId);
+
+        @SuppressWarnings("unchecked") List<PricingModel> pricingModels = query.getResultList();
+
+        return pricingModels;
+    }
+}

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingPriceDimensionsModel.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingPriceDimensionsModel.java
@@ -12,15 +12,12 @@ public class PricingPriceDimensionsModel extends Model {
     private BigDecimal pricePerUnit;
     @Column(nullable = false)
     private String unit;
-    @Column(nullable = true)
     private String description;
-    @Column(nullable = true)
     private String beginRange;
-    @Column(nullable = true)
     private String endRange;
 
     @ManyToOne
-    @JoinColumn(name="pricingTermsModelId", nullable=true)
+    @JoinColumn(name="pricingTermsModelId")
     private PricingTermsModel pricingTermsModel;
 
     public PricingPriceDimensionsModel(BigDecimal pricePerUnit, String unit, String description, String beginRange, String endRange) {

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingPriceDimensionsModel.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingPriceDimensionsModel.java
@@ -1,0 +1,84 @@
+package io.github.cloudiator.persistance;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.math.BigDecimal;
+
+@Entity
+public class PricingPriceDimensionsModel extends Model {
+    @Column(nullable = false, precision = 12, scale = 4)
+    private BigDecimal pricePerUnit;
+    @Column(nullable = false)
+    private String unit;
+    @Column(nullable = true)
+    private String description;
+    @Column(nullable = true)
+    private String beginRange;
+    @Column(nullable = true)
+    private String endRange;
+
+    @ManyToOne
+    @JoinColumn(name="pricingTermsModelId", nullable=true)
+    private PricingTermsModel pricingTermsModel;
+
+    public PricingPriceDimensionsModel(BigDecimal pricePerUnit, String unit, String description, String beginRange, String endRange) {
+        this.pricePerUnit = pricePerUnit;
+        this.unit = unit;
+        this.description = description;
+        this.beginRange = beginRange;
+        this.endRange = endRange;
+    }
+
+    protected PricingPriceDimensionsModel() {
+    }
+
+    public BigDecimal getPricePerUnit() {
+        return pricePerUnit;
+    }
+
+    public void setPricePerUnit(BigDecimal pricePerUnit) {
+        this.pricePerUnit = pricePerUnit;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBeginRange() {
+        return beginRange;
+    }
+
+    public void setBeginRange(String beginRange) {
+        this.beginRange = beginRange;
+    }
+
+    public String getEndRange() {
+        return endRange;
+    }
+
+    public void setEndRange(String endRange) {
+        this.endRange = endRange;
+    }
+
+    public PricingTermsModel getPricingTermsModel() {
+        return pricingTermsModel;
+    }
+
+    public void setPricingTermsModel(PricingTermsModel pricingTermsModel) {
+        this.pricingTermsModel = pricingTermsModel;
+    }
+}

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingTermsModel.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingTermsModel.java
@@ -7,11 +7,8 @@ import java.util.List;
 public class PricingTermsModel extends Model {
     @Column(nullable = false)
     private String termsType; // e.g. OnDemand, Reserved
-    @Column(nullable = true)
     private String leaseContractLength;
-    @Column(nullable = true)
     private String offeringClass;
-    @Column(nullable = true)
     private String purchaseOption;
 
     @ManyToOne

--- a/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingTermsModel.java
+++ b/iaas-common/src/main/java/io/github/cloudiator/persistance/PricingTermsModel.java
@@ -1,0 +1,83 @@
+package io.github.cloudiator.persistance;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+public class PricingTermsModel extends Model {
+    @Column(nullable = false)
+    private String termsType; // e.g. OnDemand, Reserved
+    @Column(nullable = true)
+    private String leaseContractLength;
+    @Column(nullable = true)
+    private String offeringClass;
+    @Column(nullable = true)
+    private String purchaseOption;
+
+    @ManyToOne
+    @JoinColumn(name="pricingModelId", nullable=false)
+    private PricingModel pricingModel;
+
+    @OneToMany(mappedBy="pricingTermsModel", cascade = CascadeType.ALL)
+    private List<PricingPriceDimensionsModel> pricingPriceDimensionsModels;
+
+    public PricingTermsModel(String leaseContractLength, String offeringClass, String purchaseOption, List<PricingPriceDimensionsModel> pricingPriceDimensionsModels, String termsType, PricingModel pricingModel) {
+        this.leaseContractLength = leaseContractLength;
+        this.offeringClass = offeringClass;
+        this.purchaseOption = purchaseOption;
+        this.pricingPriceDimensionsModels = pricingPriceDimensionsModels;
+        this.termsType = termsType;
+        this.pricingModel = pricingModel;
+    }
+
+    protected PricingTermsModel() {
+    }
+
+    public String getLeaseContractLength() {
+        return leaseContractLength;
+    }
+
+    public void setLeaseContractLength(String leaseContractLength) {
+        this.leaseContractLength = leaseContractLength;
+    }
+
+    public String getOfferingClass() {
+        return offeringClass;
+    }
+
+    public void setOfferingClass(String offeringClass) {
+        this.offeringClass = offeringClass;
+    }
+
+    public String getPurchaseOption() {
+        return purchaseOption;
+    }
+
+    public void setPurchaseOption(String purchaseOption) {
+        this.purchaseOption = purchaseOption;
+    }
+
+    public List<PricingPriceDimensionsModel> getPricingPriceDimensionsModels() {
+        return pricingPriceDimensionsModels;
+    }
+
+    public void setPricingPriceDimensionsModels(List<PricingPriceDimensionsModel> pricingPriceDimensionsModels) {
+        this.pricingPriceDimensionsModels = pricingPriceDimensionsModels;
+    }
+
+    public String getTermsType() {
+        return termsType;
+    }
+
+    public void setTermsType(String termsType) {
+        this.termsType = termsType;
+    }
+
+    public PricingModel getPricingModel() {
+        return pricingModel;
+    }
+
+    public void setPricingModel(PricingModel pricingModel) {
+        this.pricingModel = pricingModel;
+    }
+}


### PR DESCRIPTION
Adding Pricing domain and model repositories plus converter and DiscoveredPricing encapsulation class
Adding Pricing Discovery Worker and Listener
Moving DiscoveryService from AbstractDiscoveryWorker to implementing classes because new type of service, namely PricingService, entered the discovery mechanism
Removing final from scheduling methods to allow overriding schedule
Adding Pricing Query Subscriber with specialized converter
Extending ApiDomainRepository, OperatingSystemDomainRepository/OperatingSystemModelRepository with new methods
Hooking up into the existing infrastructure (DiscoveryAgent, DiscoveryModule, JpaModule) plus logback configuration and pom
